### PR TITLE
Fix creating minishift adapter

### DIFF
--- a/src/util/serverModel.ts
+++ b/src/util/serverModel.ts
@@ -53,6 +53,9 @@ export class ServerModel {
                 'server.home.dir': serverBeans[0].location
             }
         };
+        if (serverBeans[0].typeCategory === 'MINISHIFT') {
+            serverAttributes.attributes['server.home.file'] = serverBeans[0].location;
+        }
         return Common.sendSimpleRequest(this.connection, Messages.Server.CreateServerRequest.type, serverAttributes,
             timeout, ErrorMessages.CREATESERVER_TIMEOUT);
     }
@@ -73,6 +76,9 @@ export class ServerModel {
                 'server.home.dir': serverBean.location
             }
         };
+        if (serverBean.typeCategory === 'MINISHIFT') {
+            serverAttributes.attributes['server.home.file'] = serverBean.location;
+        }
         return Common.sendSimpleRequest(this.connection, Messages.Server.CreateServerRequest.type, serverAttributes,
             timeout, ErrorMessages.CREATESERVER_TIMEOUT);
     }
@@ -110,6 +116,9 @@ export class ServerModel {
                     'server.home.dir': serverBeans[0].location
                 }
             };
+            if (serverBeans[0].typeCategory === 'MINISHIFT') {
+                serverAttributes.attributes['server.home.file'] = serverBeans[0].location;
+            }
 
             result = this.connection.sendRequest(Messages.Server.CreateServerRequest.type, serverAttributes);
         });
@@ -148,6 +157,9 @@ export class ServerModel {
                     'server.home.dir': serverBean.location
                 }
             };
+            if (serverBean.typeCategory === 'MINISHIFT') {
+                serverAttributes.attributes['server.home.file'] = serverBean.location;
+            }
             result = this.connection.sendRequest(Messages.Server.CreateServerRequest.type, serverAttributes);
         });
     }

--- a/test/serverModel-test.ts
+++ b/test/serverModel-test.ts
@@ -299,7 +299,7 @@ describe('Sever Model Utility', () => {
                 expect(unregSpy).calledOnceWith('serverAdded');
             });
 
-            it('createServerFromPath should only react to server event with the correct id', async () => {
+            it('createServerFromBean should only react to server event with the correct id', async () => {
                 const unregSpy = sandbox.spy(emitter, 'removeListener');
 
                 setTimeout(() => {
@@ -314,7 +314,36 @@ describe('Sever Model Utility', () => {
                 }
             });
 
-            it('createServerFromPath should error on timeout', async () => {
+            it('createServerFromBean should work with minishift', async () => {
+                const bean: Protocol.ServerBean = {
+                    fullVersion: '1',
+                    location: 'location',
+                    name: 'server',
+                    serverAdapterTypeId: 'adapter',
+                    specificType: 'specificServer',
+                    typeCategory: 'MINISHIFT',
+                    version: '1'
+                };
+
+                const attrs: Protocol.ServerAttributes = {
+                    id: serverBean.name,
+                    serverType: serverBean.serverAdapterTypeId,
+                    attributes: {
+                        'server.home.dir': bean.location,
+                        'server.home.file': bean.location
+                    }
+                };
+                setTimeout(() => {
+                    emitter.emit('serverAdded', serverHandle1);
+                }, 1);
+
+                const result = await model.createServerFromBean(bean);
+
+                expect(result).equals(serverHandle1);
+                expect(stub).calledOnceWith(Messages.Server.CreateServerRequest.type, attrs);
+            });
+
+            it('createServerFromBean should error on timeout', async () => {
                 try {
                     await model.createServerFromBean(serverBean, 'id', 1);
                     expect.fail('No error thrown on timeout');


### PR DESCRIPTION
turns out minishift uses server.home.file instead of server.home.dir to create an adapter.